### PR TITLE
Fix deprecated annotation in helm template

### DIFF
--- a/deploy/example-webhook/templates/apiservice.yaml
+++ b/deploy/example-webhook/templates/apiservice.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "example-webhook.servingCertificate" . }}"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "example-webhook.servingCertificate" . }}"
 spec:
   group: {{ .Values.groupName }}
   groupPriorityMinimum: 1000


### PR DESCRIPTION
This deprecated annotation cause the communication between apiserver and the webhook to fail with the following message:

```
loading OpenAPI spec for "v1alpha1.acme.example.com" failed with: failed to retrieve openAPI spec, http error: ResponseCode: 503, Body: Error trying to reach service: 'x509: certificate signed by unknown authority'
```