### PR TITLE
Change apiVersion of cert-manager in APIService to the up to date one

### DIFF
--- a/deploy/example-webhook/templates/apiservice.yaml
+++ b/deploy/example-webhook/templates/apiservice.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "example-webhook.servingCertificate" . }}"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "example-webhook.servingCertificate" . }}"
 spec:
   group: {{ .Values.groupName }}
   groupPriorityMinimum: 1000


### PR DESCRIPTION
The annotation in the APIService references the old cert-manager apiVersion. This change fixes that.