### PR TITLE
update script to fetch test binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Ignore the built binary
 cert-manager-webhook-example
+
+# Test Binaries
+kubebuilder

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	zone = os.Getenv("TEST_ZONE_NAME")
+	kubeBuilderBinPath = "./kubebuilder/bin"
 )
 
 func TestRunsSuite(t *testing.T) {
@@ -17,6 +18,7 @@ func TestRunsSuite(t *testing.T) {
 	// ChallengeRequest passed as part of the test cases.
 
 	fixture := dns.NewFixture(&customDNSProviderSolver{},
+		dns.SetBinariesPath(kubeBuilderBinPath),
 		dns.SetResolvedZone(zone),
 		dns.SetAllowAmbientCredentials(false),
 		dns.SetManifestPath("testdata/my-custom-solver"),

--- a/scripts/fetch-test-binaries.sh
+++ b/scripts/fetch-test-binaries.sh
@@ -1,1 +1,10 @@
 #!/usr/bin/env bash
+os=$(go env GOOS)
+arch=$(go env GOARCH)
+
+# download kubebuilder and extract it to tmp
+curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+
+# move to a long-term location and put it on your path
+# (you'll need to set the KUBEBUILDER_ASSETS env var if you put it somewhere else)
+mv /tmp/kubebuilder_2.3.1_${os}_${arch} ./kubebuilder


### PR DESCRIPTION
Hey folks 👋  

I'm super new to Go so I'm kinda struggling to setup my webhook from this example repo 🙈  I did notice there was some chatter in https://github.com/jetstack/cert-manager-webhook-example/issues/3 to make this a little simpler for beginners so I thought I would update the script that downloads the binary files. 

I know there was an example script in that issue but I instead took inspiration from https://go.kubebuilder.io/quick-start.html 👍  

Let me know if you want me to update anything to help get this merged